### PR TITLE
cards: deck.Shuffle, deck.Reorder; never use *Card; state.Era()

### DIFF
--- a/twistr/card.go
+++ b/twistr/card.go
@@ -18,27 +18,41 @@ func (c Card) String() string {
 }
 
 type Deck struct {
-	cards []*Card
+	cards []Card
 }
 
-func (d *Deck) Shuffle() {
-	deckLen := len(d.cards)
-	for i := 0; i < 2*deckLen; i++ {
-		x := rand.Intn(deckLen)
-		d.cards[i], d.cards[x] = d.cards[x], d.cards[i]
+// Shuffle does not modify the deck in place, but rather returns the new order
+// of its cards. Use Reorder to change the deck's order.
+func (d *Deck) Shuffle() []Card {
+	order := make([]Card, len(d.cards))
+	for i, j := range rand.Perm(len(d.cards)) {
+		order[i] = d.cards[j]
+	}
+	return order
+}
+
+func (d *Deck) Reorder(ordering []Card) {
+	curLen := len(d.cards)
+	var i int
+	var c Card
+	// Assign in-place until we reach the current bound of the deck
+	for i, c = range ordering {
+		if i == curLen {
+			break
+		}
+		d.cards[i] = c
+	}
+	// If the ordering introduced more cards, push them on the end
+	if i < len(ordering) {
+		d.cards = append(d.cards, ordering[i:])
 	}
 }
 
-func (d *Deck) ShuffleIn(cards []*Card) {
-	d.cards = append(d.cards, cards...)
-	d.Shuffle()
+func (d *Deck) Push(cards ...Card) {
+	d.cards = append(d.cards, card...)
 }
 
-func (d *Deck) Push(card *Card) {
-	d.cards = append(d.cards, card)
-}
-
-func (d *Deck) Draw(n int) (draws []*Card) {
+func (d *Deck) Draw(n int) (draws []Card) {
 	draws, d.cards = d.cards[:n], d.cards[n:]
 	return
 }

--- a/twistr/const.go
+++ b/twistr/const.go
@@ -565,7 +565,7 @@ func lookupCard(name string) (Card, error) {
 	if !ok {
 		return Card{}, errors.New("Unknown card '" + name + "'")
 	}
-	return *Cards[cid], nil
+	return Cards[cid], nil
 }
 
 func lookupRegion(name string) (Region, error) {

--- a/twistr/game.go
+++ b/twistr/game.go
@@ -3,6 +3,13 @@ package twistr
 // Game-running functions.
 // Each function should represent a state in the game.
 
+// Deck / Hand states.
+// Special cards:
+// StarWars: search discard
+// SALTNegotiations: search discard
+// AskNotWhatYourCountry: discard up to hand, draw replacements
+// OurManInTehran: draw top 5, return or discard, reshuffle
+
 // WIP
 func PlayCard(s *State, c *CardPlayLog) {
 	switch {

--- a/twistr/init_cards.go
+++ b/twistr/init_cards.go
@@ -1,17 +1,17 @@
 package twistr
 
 var (
-	Cards    map[CardId]*Card
+	Cards    map[CardId]Card
 	EarlyWar []CardId
 	MidWar   []CardId
 	LateWar  []CardId
 )
 
 func init() {
-	Cards = make(map[CardId]*Card)
+	Cards = make(map[CardId]Card)
 	// XXX: always includes optional cards atm
 	for _, c := range cardTable {
-		card := &Card{
+		card := Card{
 			Id:   c.Id,
 			Aff:  c.Aff,
 			Ops:  c.Ops,

--- a/twistr/state.go
+++ b/twistr/state.go
@@ -24,7 +24,7 @@ type State struct {
 
 	Deck *Deck
 
-	Hands [2]map[CardId]*Card
+	Hands [2]map[CardId]Card
 
 	ChinaCardPlayer Aff
 	ChinaCardFaceUp bool
@@ -40,6 +40,17 @@ func NewState(input Input) *State {
 		AR:              1,
 		ChinaCardPlayer: Sov,
 		ChinaCardFaceUp: true,
+	}
+}
+
+func (s *State) Era() Era {
+	switch {
+	case s.Turn < 4:
+		return Early
+	case s.Turn < 8:
+		return Mid
+	default:
+		return Late
 	}
 }
 


### PR DESCRIPTION
Fixes #25 but not completely: the specified features are part of broader game states. Namely, initial setup and turn end. Rather than building the card-related portions of those states under this PR, I'm choosing to change limit the scope of the task/PR to what I've provided here. The card-related portions of #11 and #13 should be done in their respective PRs.
